### PR TITLE
Support apple silicon

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -39,6 +39,12 @@ dependencies {
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${revProtoBuf}"
+        // for apple m1, add protoc_platform=osx-x86_64 in $HOME/.gradle/gradle.properties
+        if (project.hasProperty('protoc_platform')) {
+            artifact = "com.google.protobuf:protoc:3.9.2:${protoc_platform}"
+        } else {
+            artifact = "com.google.protobuf:protoc:3.9.2"
+        }
     }
     plugins {
         grpc {


### PR DESCRIPTION
Allow running conductor locally with `./gradlew bootRun -x test`