### PR TITLE
[ROUT-5496] Propagate user UUID

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/ActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/ActionProcessor.java
@@ -22,5 +22,9 @@ public interface ActionProcessor {
             EventHandler.Action action, Object payloadObject, String event, String messageId);
 
     Map<String, Object> execute(
-            EventHandler.Action action, Object payloadObject, String event, String messageId, String userIdentifier);
+            EventHandler.Action action,
+            Object payloadObject,
+            String event,
+            String messageId,
+            String userIdentifier);
 }

--- a/core/src/main/java/com/netflix/conductor/core/events/ActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/ActionProcessor.java
@@ -20,4 +20,7 @@ public interface ActionProcessor {
 
     Map<String, Object> execute(
             EventHandler.Action action, Object payloadObject, String event, String messageId);
+
+    Map<String, Object> execute(
+            EventHandler.Action action, Object payloadObject, String event, String messageId, String userIdentifier);
 }

--- a/core/src/main/java/com/netflix/conductor/core/events/DefaultEventProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/DefaultEventProcessor.java
@@ -259,7 +259,8 @@ public class DefaultEventProcessor {
      *     completed/failed with non-transient error the input event execution, if the execution
      *     failed due to transient error
      */
-    protected EventExecution execute(EventExecution eventExecution, Action action, Object payload, String userIdentifier) {
+    protected EventExecution execute(
+            EventExecution eventExecution, Action action, Object payload, String userIdentifier) {
         try {
             LOGGER.debug(
                     "Executing action: {} for event: {} with messageId: {} with payload: {}",

--- a/core/src/main/java/com/netflix/conductor/core/events/DefaultEventProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/DefaultEventProcessor.java
@@ -241,7 +241,8 @@ public class DefaultEventProcessor {
                                         execute(
                                                 eventExecution,
                                                 action,
-                                                getPayloadObject(msg.getPayload())),
+                                                getPayloadObject(msg.getPayload()),
+                                                msg.getUserIdentifier()),
                                 eventActionExecutorService));
             } else {
                 LOGGER.warn("Duplicate delivery/execution of message: {}", msg.getId());
@@ -258,7 +259,7 @@ public class DefaultEventProcessor {
      *     completed/failed with non-transient error the input event execution, if the execution
      *     failed due to transient error
      */
-    protected EventExecution execute(EventExecution eventExecution, Action action, Object payload) {
+    protected EventExecution execute(EventExecution eventExecution, Action action, Object payload, String userIdentifier) {
         try {
             LOGGER.debug(
                     "Executing action: {} for event: {} with messageId: {} with payload: {}",
@@ -274,7 +275,8 @@ public class DefaultEventProcessor {
                                             action,
                                             payload,
                                             eventExecution.getEvent(),
-                                            eventExecution.getMessageId()));
+                                            eventExecution.getMessageId(),
+                                            userIdentifier));
             if (output != null) {
                 eventExecution.getOutput().putAll(output);
             }

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -59,12 +59,17 @@ public class SimpleActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public Map<String, Object> execute(Action action, Object payloadObject, String event, String messageId) {
+    public Map<String, Object> execute(
+            Action action, Object payloadObject, String event, String messageId) {
         return execute(action, payloadObject, event, messageId, null);
     }
 
     public Map<String, Object> execute(
-            Action action, Object payloadObject, String event, String messageId, String userIdentifier) {
+            Action action,
+            Object payloadObject,
+            String event,
+            String messageId,
+            String userIdentifier) {
 
         LOGGER.debug(
                 "Executing action: {} for event: {} with messageId:{}",

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -58,8 +58,13 @@ public class SimpleActionProcessor implements ActionProcessor {
         this.jsonUtils = jsonUtils;
     }
 
+    @Override
+    public Map<String, Object> execute(Action action, Object payloadObject, String event, String messageId) {
+        return execute(action, payloadObject, event, messageId, null);
+    }
+
     public Map<String, Object> execute(
-            Action action, Object payloadObject, String event, String messageId) {
+            Action action, Object payloadObject, String event, String messageId, String userIdentifier) {
 
         LOGGER.debug(
                 "Executing action: {} for event: {} with messageId:{}",
@@ -74,7 +79,7 @@ public class SimpleActionProcessor implements ActionProcessor {
 
         switch (action.getAction()) {
             case start_workflow:
-                return startWorkflow(action, jsonObject, event, messageId);
+                return startWorkflow(action, jsonObject, event, messageId, userIdentifier);
             case complete_task:
                 return completeTask(
                         action,
@@ -199,7 +204,7 @@ public class SimpleActionProcessor implements ActionProcessor {
     }
 
     private Map<String, Object> startWorkflow(
-            Action action, Object payload, String event, String messageId) {
+            Action action, Object payload, String event, String messageId, String userIdentifier) {
         StartWorkflow params = action.getStart_workflow();
         Map<String, Object> output = new HashMap<>();
         try {
@@ -218,13 +223,15 @@ public class SimpleActionProcessor implements ActionProcessor {
             String workflowName = (String) workflowInput.get("workflowName");
             Integer version = (Integer) workflowInput.get("version");
 
-            LOGGER.info("start workflow correlationId: {}", replaced.get("correlationId"));
-
             workflowInput.put("conductor.event.messageId", messageId);
             workflowInput.put("conductor.event.name", event);
 
             params.setName(workflowName);
             params.setVersion(version);
+
+            if (userIdentifier != null) {
+                workflowInput.put("userIdentifier", userIdentifier);
+            }
 
             String workflowId =
                     workflowExecutor.startWorkflow(

--- a/core/src/main/java/com/netflix/conductor/core/events/queue/Message.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/Message.java
@@ -19,6 +19,7 @@ public class Message {
     private String payload;
     private String id;
     private String receipt;
+    private String userIdentifier;
     private int priority;
 
     public Message() {}
@@ -76,6 +77,14 @@ public class Message {
      */
     public void setReceipt(String receipt) {
         this.receipt = receipt;
+    }
+
+    public String getUserIdentifier() {
+        return this.userIdentifier;
+    }
+
+    public void setUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -69,6 +69,10 @@ public class SubWorkflow extends WorkflowSystemTask {
         }
         String correlationId = workflow.getCorrelationId();
 
+        if (workflow.getUserIdentifier() != null) {
+            wfInput.put("userIdentifier", workflow.getUserIdentifier());
+        }
+
         try {
             String subWorkflowId;
             if (workflowDefinition != null) {

--- a/core/src/main/java/com/netflix/conductor/core/tracing/Tracing.java
+++ b/core/src/main/java/com/netflix/conductor/core/tracing/Tracing.java
@@ -39,6 +39,12 @@ public class Tracing {
         return Optional.empty();
     }
 
+    public void setUserIdentifier(String userIdentifier) {
+        if (this.span.isPresent()) {
+            this.span.get().setAttribute("id", userIdentifier);
+        }
+    }
+
     public void finish() {
         if (this.span.isPresent()) {
             Span span = this.span.get();

--- a/core/src/main/java/com/netflix/conductor/core/tracing/TracingProvider.java
+++ b/core/src/main/java/com/netflix/conductor/core/tracing/TracingProvider.java
@@ -63,7 +63,7 @@ public class TracingProvider {
                             options.setTracesSampleRate(tracingProperties.getTracesSamplingRate());
                             options.setInstrumenter(Instrumenter.OTEL);
                             options.addEventProcessor(new OpenTelemetryLinkErrorEventProcessor());
-                            options.setDebug(true);
+                            options.setDebug(false);
                         });
 
                 Resource resource =

--- a/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/WorkflowModel.java
@@ -66,6 +66,8 @@ public class WorkflowModel {
 
     private String correlationId;
 
+    private String userIdentifier;
+
     private String reRunFromWorkflowId;
 
     private String reasonForIncompletion;
@@ -239,6 +241,14 @@ public class WorkflowModel {
 
     public void setCorrelationId(String correlationId) {
         this.correlationId = correlationId;
+    }
+
+    public String getUserIdentifier() {
+        if (this.getInput() != null && this.getInput().containsKey("userIdentifier")) {
+            return this.getInput().get("userIdentifier").toString();
+        }
+
+        return null;
     }
 
     public String getReRunFromWorkflowId() {

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -39,6 +39,12 @@ dependencies {
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${revProtoBuf}"
+        // for apple m1, add protoc_platform=osx-x86_64 in $HOME/.gradle/gradle.properties
+        if (project.hasProperty('protoc_platform')) {
+            artifact = "com.google.protobuf:protoc:3.9.2:${protoc_platform}"
+        } else {
+            artifact = "com.google.protobuf:protoc:3.9.2"
+        }
     }
     plugins {
         grpc {


### PR DESCRIPTION
Dependency: https://github.com/routific/conductor-community/pull/3

- On incoming kafka events (start-workflow, complete-task, fail-task) Parse kafka header for `user-uuid` and set span attribute `id` with uuid (https://github.com/routific/conductor-community/pull/3/files#diff-33be5d1d416adf64056b730d76e42a9b5da444bba0ff5fe52184378125786cbfR42)
- On start-workflow, persist to db as workflow input `userIdentifier` property. (https://github.com/routific/conductor/pull/20/files#diff-1cc510c57a95314d72e9220e113a60a368c9780ef4bd7d28e0637c83f99f11cbR237-R239)
- When publishing message, retrieve workflow's `userIdentifier` and propagate to downstream services as `user-uuid` header.  (https://github.com/routific/conductor-community/pull/3/files#diff-07ab9d981b6f570fba3d676feb6e520ebb4a858f3f1b30844c0bd4c423c53d02)